### PR TITLE
[Feature] 메인페이지 InputBar 구현

### DIFF
--- a/client/src/base/component.js
+++ b/client/src/base/component.js
@@ -1,13 +1,12 @@
 import store from '@/store';
 
 export default class Component {
-  constructor(parentNode, tagName, attrs) {
+  constructor(parentNode, tagName, attrs, initialData) {
     this.parentNode = parentNode;
     this.currentNode = document.createElement(tagName);
     this.setAttributes(attrs);
 
-    this.render();
-    this.activate();
+    this.render(initialData);
     this.parentNode.appendChild(this.currentNode);
   }
 

--- a/client/src/components/Header/HeaderCalendar/index.js
+++ b/client/src/components/Header/HeaderCalendar/index.js
@@ -5,6 +5,7 @@ import dateUtil from '@/utils/date-util';
 export default class HeaderCalendar extends Component {
   constructor(parentNode) {
     super(parentNode, 'div', { class: 'header-calendar' });
+    this.activate();
   }
 
   render(currentHeaderDate) {

--- a/client/src/components/Header/HeaderCalendar/index.js
+++ b/client/src/components/Header/HeaderCalendar/index.js
@@ -1,7 +1,7 @@
 import Component from '@/base/component';
 import { STORE_KEYS } from '@/constants/keys';
 import controller from '@/controller';
-import dateUtil from '@/utils/date-util';
+import { getYearAndMonth } from '@/utils/date-util';
 export default class HeaderCalendar extends Component {
   constructor(parentNode) {
     super(parentNode, 'div', { class: 'header-calendar' });
@@ -10,7 +10,7 @@ export default class HeaderCalendar extends Component {
 
   render(currentHeaderDate) {
     if (!currentHeaderDate) return;
-    const { year, month } = dateUtil.getYearAndMonth(currentHeaderDate);
+    const { year, month } = getYearAndMonth(currentHeaderDate);
     this.currentNode.innerHTML = `
         <button class='header-calendar__button--prev'><</button>
         <div class='header-calendar__container'>

--- a/client/src/components/Header/Logo/index.js
+++ b/client/src/components/Header/Logo/index.js
@@ -8,7 +8,7 @@ export default class Logo extends Component {
   render() {
     this.currentNode.innerHTML = `
       <a class="link font-dohyeon" href="/">
-        우아우아한 가계부
+        우아한 가계부
       </a>
     `;
   }

--- a/client/src/components/Header/index.js
+++ b/client/src/components/Header/index.js
@@ -8,6 +8,7 @@ import HeaderCalendar from './HeaderCalendar';
 export default class Header extends Component {
   constructor(parentNode) {
     super(parentNode, 'header', { class: 'header' });
+    this.activate();
   }
 
   render() {

--- a/client/src/components/InputBar/CategoryInput/index.js
+++ b/client/src/components/InputBar/CategoryInput/index.js
@@ -1,0 +1,33 @@
+import Component from '@/base/component';
+import Dropdown from '../Dropdown';
+import { STORE_KEYS, INPUT_BAR_KEYS } from '@/constants/keys';
+
+export default class CategoryInput extends Component {
+  constructor(parentNode, categoryInputData) {
+    super(parentNode, 'label', { class: 'input-box' }, categoryInputData);
+    this.activate();
+  }
+
+  render(categoryInputData) {
+    this.currentNode.innerHTML = `
+        <h4 class="input__title">분류</h4>
+        <input readonly class="input input__category" name="category" type="text" placeholder="선택하세요" value="${
+          categoryInputData?.title || ''
+        }">        
+        `;
+    new Dropdown(
+      this.currentNode,
+      STORE_KEYS.CATEGORIES,
+      INPUT_BAR_KEYS.CATEGORY,
+    );
+  }
+
+  activate() {
+    this.addEvent('click', '.input__category', () => this.toggleDropDown());
+  }
+
+  toggleDropDown() {
+    const dropdown = this.currentNode.querySelector('.dropdown');
+    dropdown.classList.toggle('closed');
+  }
+}

--- a/client/src/components/InputBar/ConfirmButton/index.js
+++ b/client/src/components/InputBar/ConfirmButton/index.js
@@ -1,0 +1,31 @@
+import Component from '@/base/component';
+import controller from '@/controller';
+
+export default class ConfirmButton extends Component {
+  constructor(parentNode, inputData) {
+    super(parentNode, 'div', { class: 'confirm-button-container' }, inputData);
+    this.activate();
+  }
+
+  render(inputData) {
+    const doseAllInputFilled = this.checkAllInputFilled(inputData);
+    this.currentNode.innerHTML = `
+      <button class="confirm-button" ${
+        doseAllInputFilled ? '' : 'disabled'
+      }>버튼</button>
+    `;
+  }
+
+  checkAllInputFilled(inputData) {
+    const inputValues = Object.values(inputData);
+    return inputValues.every((value) => value !== null);
+  }
+
+  activate() {
+    this.addEvent(
+      'click',
+      '.confirm-button',
+      controller.createNewTransactionHistory,
+    );
+  }
+}

--- a/client/src/components/InputBar/ConfirmButton/index.js
+++ b/client/src/components/InputBar/ConfirmButton/index.js
@@ -1,27 +1,23 @@
 import Component from '@/base/component';
 import controller from '@/controller';
+import { STORE_KEYS } from '@/constants/keys';
 
 export default class ConfirmButton extends Component {
-  constructor(parentNode, inputData) {
-    super(parentNode, 'div', { class: 'confirm-button-container' }, inputData);
+  constructor(parentNode) {
+    super(parentNode, 'div', { class: 'confirm-button-container' });
     this.activate();
   }
 
-  render(inputData) {
-    const doseAllInputFilled = this.checkAllInputFilled(inputData);
+  render(isInputBarValid) {
     this.currentNode.innerHTML = `
       <button class="confirm-button" ${
-        doseAllInputFilled ? '' : 'disabled'
+        isInputBarValid ? '' : 'disabled'
       }>버튼</button>
     `;
   }
 
-  checkAllInputFilled(inputData) {
-    const inputValues = Object.values(inputData);
-    return inputValues.every((value) => value !== null);
-  }
-
   activate() {
+    this.subscribe(STORE_KEYS.IS_INPUT_BAR_VALID);
     this.addEvent(
       'click',
       '.confirm-button',

--- a/client/src/components/InputBar/DateInput/index.js
+++ b/client/src/components/InputBar/DateInput/index.js
@@ -1,7 +1,11 @@
 import Component from '@/base/component';
-import dateUtil from '@/utils/date-util';
 import controller from '@/controller';
 import { INPUT_BAR_KEYS } from '@/constants/keys';
+import {
+  convertDateString,
+  getFirstDateOfMonth,
+  getLastDateOfMonth,
+} from '@/utils/date-util';
 
 export default class DateInput extends Component {
   constructor(parentNode, dateInputData) {
@@ -10,11 +14,11 @@ export default class DateInput extends Component {
   }
 
   render(dateInputData) {
-    const dateString = dateUtil.convertDateString(dateInputData);
-    const firstDateOfMonth = dateUtil.getFirstDateOfMonth(dateInputData);
-    const firstDateString = dateUtil.convertDateString(firstDateOfMonth);
-    const lastDateOfMonth = dateUtil.getLastDateOfMonth(dateInputData);
-    const lastDateString = dateUtil.convertDateString(lastDateOfMonth);
+    const dateString = convertDateString(dateInputData);
+    const firstDateString = convertDateString(
+      getFirstDateOfMonth(dateInputData),
+    );
+    const lastDateString = convertDateString(getLastDateOfMonth(dateInputData));
 
     this.currentNode.innerHTML = `
       <h4 class="input__title">일자</h4>

--- a/client/src/components/InputBar/DateInput/index.js
+++ b/client/src/components/InputBar/DateInput/index.js
@@ -1,0 +1,34 @@
+import Component from '@/base/component';
+import dateUtil from '@/utils/date-util';
+import controller from '@/controller';
+import { INPUT_BAR_KEYS } from '@/constants/keys';
+
+export default class DateInput extends Component {
+  constructor(parentNode, dateInputData) {
+    super(parentNode, 'label', { class: 'input-box' }, dateInputData);
+    this.activate();
+  }
+
+  render(dateInputData) {
+    const dateString = dateUtil.convertDateString(dateInputData);
+    const firstDateOfMonth = dateUtil.getFirstDateOfMonth(dateInputData);
+    const firstDateString = dateUtil.convertDateString(firstDateOfMonth);
+    const lastDateOfMonth = dateUtil.getLastDateOfMonth(dateInputData);
+    const lastDateString = dateUtil.convertDateString(lastDateOfMonth);
+
+    this.currentNode.innerHTML = `
+      <h4 class="input__title">일자</h4>
+      <input draggable="false" class="input input__date" name="date" type="date" min="${firstDateString}" max="${lastDateString}" value="${dateString}">
+    `;
+  }
+
+  activate() {
+    this.addEvent('input', '.input__date', this.handleDateInput.bind(this));
+  }
+
+  handleDateInput(event) {
+    const inputValue = event.target.value;
+    if (!inputValue) return;
+    controller.changeInputData(INPUT_BAR_KEYS.DATE, new Date(inputValue));
+  }
+}

--- a/client/src/components/InputBar/DateInput/index.js
+++ b/client/src/components/InputBar/DateInput/index.js
@@ -27,7 +27,9 @@ export default class DateInput extends Component {
   }
 
   activate() {
-    this.addEvent('input', '.input__date', this.handleDateInput.bind(this));
+    this.addEvent('input', '.input__date', (event) =>
+      this.handleDateInput(event),
+    );
   }
 
   handleDateInput(event) {

--- a/client/src/components/InputBar/Dropdown/index.js
+++ b/client/src/components/InputBar/Dropdown/index.js
@@ -26,10 +26,8 @@ export default class Dropdown extends Component {
 
   activate() {
     this.subscribe(this.storeKey);
-    this.addEvent(
-      'click',
-      '.dropdown__item',
-      this.handleDropdownItemClick.bind(this),
+    this.addEvent('click', '.dropdown__item', (event) =>
+      this.handleDropdownItemClick(event),
     );
   }
 

--- a/client/src/components/InputBar/Dropdown/index.js
+++ b/client/src/components/InputBar/Dropdown/index.js
@@ -1,0 +1,40 @@
+import Component from '@/base/component';
+import controller from '@/controller';
+
+export default class Dropdown extends Component {
+  constructor(parentNode, storeKey, inputBarKey) {
+    super(parentNode, 'div', { class: 'dropdown shadow closed' });
+    this.storeKey = storeKey;
+    this.inputBarKey = inputBarKey;
+    this.activate();
+  }
+
+  render(dropdownItemData) {
+    if (!dropdownItemData) return;
+    this.currentNode.innerHTML = `
+      <ul class="dropdown__list">
+        ${dropdownItemData
+          .map(
+            ({ id, title }) =>
+              `<li class="dropdown__item" data-id=${id} data-title=${title}>${title}</li>`,
+          )
+          .join('')}  
+      </ul>
+    `;
+  }
+
+  activate() {
+    this.subscribe(this.storeKey);
+    this.addEvent(
+      'click',
+      '.dropdown__item',
+      this.handleDropdownItemClick.bind(this),
+    );
+  }
+
+  handleDropdownItemClick(event) {
+    event.stopPropagation();
+    const { id, title } = event.target.dataset;
+    controller.changeInputData(this.inputBarKey, { id, title });
+  }
+}

--- a/client/src/components/InputBar/Dropdown/index.js
+++ b/client/src/components/InputBar/Dropdown/index.js
@@ -12,6 +12,7 @@ export default class Dropdown extends Component {
   render(dropdownItemData) {
     if (!dropdownItemData) return;
     this.currentNode.innerHTML = `
+      <div class="dropdown__backdrop"></div>
       <ul class="dropdown__list">
         ${dropdownItemData
           .map(

--- a/client/src/components/InputBar/MoneyInput/index.js
+++ b/client/src/components/InputBar/MoneyInput/index.js
@@ -1,0 +1,40 @@
+import Component from '@/base/component';
+import controller from '@/controller';
+import { INPUT_BAR_KEYS } from '@/constants/keys';
+
+export default class MoneyInput extends Component {
+  constructor(parentNode, moneyData) {
+    super(parentNode, 'label', { class: 'input-box' }, moneyData);
+    this.moneyData = moneyData;
+    this.activate();
+  }
+
+  render(moneyData) {
+    this.moneyData = moneyData;
+    const { isIncome, amount } = moneyData;
+    this.currentNode.innerHTML = `
+      <h4 class="input__title">금액</h4>
+      <div class="input__money-container">
+        <span class="input input__money-sign" name="money-sign" type="text" data-isincome=${isIncome}>${
+      isIncome ? '+' : '-'
+    }</span>
+        <input class="input input__money-amount" name="amount" type="number" placeholder='입력하세요' value="${
+          amount || ''
+        }">
+        <span>원</span>
+      </div>
+      `;
+  }
+
+  activate() {
+    this.addEvent('change', '.input__money-amount', (event) =>
+      controller.changeInputData(INPUT_BAR_KEYS.AMOUNT, event.target.value),
+    );
+    this.addEvent('click', '.input__money-sign', (event) =>
+      controller.changeInputData(
+        INPUT_BAR_KEYS.IS_INCOME,
+        !this.moneyData.isIncome,
+      ),
+    );
+  }
+}

--- a/client/src/components/InputBar/MoneyInput/index.js
+++ b/client/src/components/InputBar/MoneyInput/index.js
@@ -27,8 +27,10 @@ export default class MoneyInput extends Component {
   }
 
   activate() {
-    this.addEvent('change', '.input__money-amount', (event) =>
-      controller.changeInputData(INPUT_BAR_KEYS.AMOUNT, event.target.value),
+    this.addEvent('input', '.input__money-amount', (event) =>
+      controller.changeInputData(INPUT_BAR_KEYS.AMOUNT, event.target.value, {
+        rerender: false,
+      }),
     );
     this.addEvent('click', '.input__money-sign', (event) =>
       controller.changeInputData(

--- a/client/src/components/InputBar/PaymentMethodInput/index.js
+++ b/client/src/components/InputBar/PaymentMethodInput/index.js
@@ -1,0 +1,35 @@
+import Component from '@/base/component';
+import Dropdown from '../Dropdown';
+import { STORE_KEYS, INPUT_BAR_KEYS } from '@/constants/keys';
+
+export default class PaymentMethodInput extends Component {
+  constructor(parentNode, paymentMethodInputData) {
+    super(parentNode, 'label', { class: 'input-box' }, paymentMethodInputData);
+    this.activate();
+  }
+
+  render(paymentMethodInputData) {
+    this.currentNode.innerHTML = `
+        <h4 class="input__title">분류</h4>
+        <input readonly class="input input__payment-methods" name="category" type="text" placeholder="선택하세요" value="${
+          paymentMethodInputData?.title || ''
+        }">        
+        `;
+    new Dropdown(
+      this.currentNode,
+      STORE_KEYS.PAYMENT_METHODS,
+      INPUT_BAR_KEYS.PAYMENT_METHOD,
+    );
+  }
+
+  activate() {
+    this.addEvent('click', '.input__payment-methods', () =>
+      this.toggleDropDown(),
+    );
+  }
+
+  toggleDropDown() {
+    const dropdown = this.currentNode.querySelector('.dropdown');
+    dropdown.classList.toggle('closed');
+  }
+}

--- a/client/src/components/InputBar/TitleInput/index.js
+++ b/client/src/components/InputBar/TitleInput/index.js
@@ -17,8 +17,10 @@ export default class TitleInput extends Component {
   }
 
   activate() {
-    this.addEvent('change', '.input__content', (event) =>
-      controller.changeInputData(INPUT_BAR_KEYS.TITLE, event.target.value),
+    this.addEvent('input', '.input__content', (event) =>
+      controller.changeInputData(INPUT_BAR_KEYS.TITLE, event.target.value, {
+        rerender: false,
+      }),
     );
   }
 }

--- a/client/src/components/InputBar/TitleInput/index.js
+++ b/client/src/components/InputBar/TitleInput/index.js
@@ -1,0 +1,24 @@
+import Component from '@/base/component';
+import controller from '@/controller';
+import { INPUT_BAR_KEYS } from '@/constants/keys';
+export default class TitleInput extends Component {
+  constructor(parentNode, titleData) {
+    super(parentNode, 'label', { class: 'input-box' }, titleData);
+    this.activate();
+  }
+
+  render(titleData) {
+    this.currentNode.innerHTML = `
+      <h4 class="input__title">내용</h4>
+      <input class="input input__content" name="title" type="text" placeholder='입력하세요' value="${
+        titleData || ''
+      }">
+    `;
+  }
+
+  activate() {
+    this.addEvent('change', '.input__content', (event) =>
+      controller.changeInputData(INPUT_BAR_KEYS.TITLE, event.target.value),
+    );
+  }
+}

--- a/client/src/components/InputBar/index.css
+++ b/client/src/components/InputBar/index.css
@@ -103,6 +103,10 @@ input[type='date']::-webkit-calendar-picker-indicator {
   right: 1rem;
 }
 
+.confirm-button:disabled {
+  opacity: 0.25;
+}
+
 .closed {
   visibility: hidden;
 }

--- a/client/src/components/InputBar/index.css
+++ b/client/src/components/InputBar/index.css
@@ -82,9 +82,23 @@ input[type='date']::-webkit-calendar-picker-indicator {
   position: absolute;
   left: 0;
   top: 4.25rem;
-  background-color: var(--colors-off-white);
+}
+
+.dropdown__list {
+  position: relative;
   border-radius: 0.625rem;
   padding: 0 1.5rem;
+  background-color: var(--colors-off-white);
+  z-index: var(--z-index-dropdown);
+}
+
+.dropdown__backdrop {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: calc(var(--z-index-dropdown) - 10);
 }
 
 .dropdown__item {

--- a/client/src/components/InputBar/index.css
+++ b/client/src/components/InputBar/index.css
@@ -1,0 +1,108 @@
+.input-bar {
+  position: absolute;
+  top: -2rem;
+  display: flex;
+  padding: 1rem 0.5rem;
+  background-color: var(--colors-off-white);
+  border-radius: 0.625rem;
+  width: 56.5rem;
+}
+
+.input-box {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  height: 2.75rem;
+  justify-content: space-between;
+  padding: 0 1.5rem;
+  border-right: 1px solid var(--colors-placeholder);
+}
+
+.input-box:last-child {
+  border: 0;
+}
+
+.input__title {
+  color: var(--colors-primary);
+  font-size: 0.75rem;
+  display: block;
+}
+
+.input {
+  display: block;
+}
+
+.input__date {
+  font-size: 0.75rem;
+  width: 5rem;
+}
+
+.input__category {
+  width: 6.25rem;
+}
+
+.input__content {
+  width: 10.75rem;
+}
+
+.input__payment-methods {
+  width: 6.25rem;
+}
+
+.input__money-container {
+  width: 9rem;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.input__money-sign {
+  line-height: 2rem;
+  font-size: 2rem;
+}
+
+.input__money-amount {
+  width: 6rem;
+  text-align: right;
+}
+
+input[type='number']::-webkit-outer-spin-button,
+input[type='number']::-webkit-inner-spin-button {
+  -webkit-appearance: none;
+  margin: 0;
+}
+
+input[type='date']::-webkit-inner-spin-button,
+input[type='date']::-webkit-calendar-picker-indicator {
+  display: none;
+  -webkit-appearance: none;
+}
+
+.dropdown {
+  position: absolute;
+  left: 0;
+  top: 4.25rem;
+  background-color: var(--colors-off-white);
+  border-radius: 0.625rem;
+  padding: 0 1.5rem;
+}
+
+.dropdown__item {
+  width: 6.25rem;
+  padding: 1rem 0;
+  border-bottom: 1px solid var(--colors-placeholder);
+}
+
+.dropdown__item:last-child {
+  border: 0;
+}
+
+.confirm-button-container {
+  position: absolute;
+  top: 2rem;
+  right: 1rem;
+}
+
+.closed {
+  visibility: hidden;
+}

--- a/client/src/components/InputBar/index.js
+++ b/client/src/components/InputBar/index.js
@@ -19,7 +19,7 @@ export default class InputBar extends Component {
     const { date, title, category, paymentMethod, isIncome, amount } =
       inputBarData;
     this.currentNode.innerHTML = '';
-    new ConfirmButton(this.currentNode, inputBarData);
+    new ConfirmButton(this.currentNode);
     new DateInput(this.currentNode, date);
     new CategoryInput(this.currentNode, category);
     new TitleInput(this.currentNode, title);

--- a/client/src/components/InputBar/index.js
+++ b/client/src/components/InputBar/index.js
@@ -1,0 +1,33 @@
+import Component from '@/base/component';
+import './index.css';
+import DateInput from './DateInput';
+import TitleInput from './TitleInput';
+import CategoryInput from './CategoryInput';
+import PaymentMethodInput from './PaymentMethodInput';
+import MoneyInput from './MoneyInput';
+import ConfirmButton from './ConfirmButton';
+import { STORE_KEYS } from '@/constants/keys';
+
+export default class InputBar extends Component {
+  constructor(parentNode) {
+    super(parentNode, 'form', { class: 'input-bar shadow' });
+    this.activate();
+  }
+
+  render(inputBarData) {
+    if (!inputBarData) return;
+    const { date, title, category, paymentMethod, isIncome, amount } =
+      inputBarData;
+    this.currentNode.innerHTML = '';
+    new ConfirmButton(this.currentNode, inputBarData);
+    new DateInput(this.currentNode, date);
+    new CategoryInput(this.currentNode, category);
+    new TitleInput(this.currentNode, title);
+    new PaymentMethodInput(this.currentNode, paymentMethod);
+    new MoneyInput(this.currentNode, { isIncome, amount });
+  }
+
+  activate() {
+    this.subscribe(STORE_KEYS.INPUT_BAR_DATA);
+  }
+}

--- a/client/src/constants/keys.js
+++ b/client/src/constants/keys.js
@@ -6,3 +6,12 @@ export const STORE_KEYS = {
   INPUT_BAR_DATA: 'inputBarData',
   INPUT_BAR_STATE: 'inputBarState',
 };
+
+export const INPUT_BAR_KEYS = {
+  DATE: 'date',
+  CATEGORY: 'category',
+  PAYMENT_METHOD: 'paymentMethod',
+  IS_INCOME: 'isIncome',
+  AMOUNT: 'amount',
+  TITLE: 'title',
+};

--- a/client/src/constants/keys.js
+++ b/client/src/constants/keys.js
@@ -5,6 +5,7 @@ export const STORE_KEYS = {
   PAYMENT_METHODS: 'paymentMethods',
   INPUT_BAR_DATA: 'inputBarData',
   INPUT_BAR_STATE: 'inputBarState',
+  IS_INPUT_BAR_VALID: 'isInputBarValid',
 };
 
 export const INPUT_BAR_KEYS = {

--- a/client/src/controller/index.js
+++ b/client/src/controller/index.js
@@ -1,5 +1,7 @@
 import store from '@/store';
 import { STORE_KEYS } from '@/constants/keys';
+import request from '@/utils/api-util';
+import dateUtil from '@/utils/date-util';
 
 function changeHeaderMonth(increment) {
   const currDate = store.getData(STORE_KEYS.CURRENT_HEADER_DATE);
@@ -9,9 +11,47 @@ function changeHeaderMonth(increment) {
   store.setData(STORE_KEYS.CURRENT_HEADER_DATE, changedDate);
 }
 
+function changeInputData(dataKey, data) {
+  const currInputData = store.getData(STORE_KEYS.INPUT_BAR_DATA);
+  const updatedData = { ...currInputData };
+  updatedData[dataKey] = data;
+  store.setData(STORE_KEYS.INPUT_BAR_DATA, updatedData);
+}
+
+async function createNewTransactionHistory(event) {
+  event.preventDefault();
+  const currInputData = store.getData(STORE_KEYS.INPUT_BAR_DATA);
+  const { title, date, category, paymentMethod, isIncome, amount } =
+    currInputData;
+  const formattedDate = dateUtil.convertDateString(date);
+  await request.createTransactionHistory(
+    title,
+    formattedDate,
+    category.id,
+    paymentMethod.id,
+    isIncome,
+    amount,
+  );
+  clearInputBar();
+}
+
+function clearInputBar() {
+  const clearedInputBarData = {
+    title: null,
+    date: new Date(),
+    category: null,
+    paymentMethod: null,
+    isIncome: false,
+    amount: null,
+  };
+  store.setData(STORE_KEYS.INPUT_BAR_DATA, clearedInputBarData);
+}
+
 const controller = {
   decreaseMonth: () => changeHeaderMonth(-1),
   increaseMonth: () => changeHeaderMonth(1),
+  changeInputData: (key, data) => changeInputData(key, data),
+  createNewTransactionHistory,
 };
 
 export default controller;

--- a/client/src/controller/index.js
+++ b/client/src/controller/index.js
@@ -11,11 +11,17 @@ function changeHeaderMonth(increment) {
   store.setData(STORE_KEYS.CURRENT_HEADER_DATE, changedDate);
 }
 
-function changeInputData(dataKey, data) {
+function changeInputData(dataKey, data, options) {
   const currInputData = store.getData(STORE_KEYS.INPUT_BAR_DATA);
   const updatedData = { ...currInputData };
   updatedData[dataKey] = data;
-  store.setData(STORE_KEYS.INPUT_BAR_DATA, updatedData);
+  store.setData(STORE_KEYS.INPUT_BAR_DATA, updatedData, options);
+  const isInputBarValid = checkInputBarDataValidity(updatedData);
+  store.setData(STORE_KEYS.IS_INPUT_BAR_VALID, isInputBarValid);
+}
+
+function checkInputBarDataValidity(inputBarData) {
+  return Object.values(inputBarData).every((value) => value !== null);
 }
 
 async function createNewTransactionHistory(event) {
@@ -50,7 +56,7 @@ function clearInputBar() {
 const controller = {
   decreaseMonth: () => changeHeaderMonth(-1),
   increaseMonth: () => changeHeaderMonth(1),
-  changeInputData: (key, data) => changeInputData(key, data),
+  changeInputData: (key, data, options) => changeInputData(key, data, options),
   createNewTransactionHistory,
 };
 

--- a/client/src/controller/index.js
+++ b/client/src/controller/index.js
@@ -1,7 +1,7 @@
 import store from '@/store';
 import { STORE_KEYS } from '@/constants/keys';
 import request from '@/utils/api-util';
-import dateUtil from '@/utils/date-util';
+import { convertDateString } from '@/utils/date-util';
 
 function changeHeaderMonth(increment) {
   const currDate = store.getData(STORE_KEYS.CURRENT_HEADER_DATE);
@@ -29,7 +29,7 @@ async function createNewTransactionHistory(event) {
   const currInputData = store.getData(STORE_KEYS.INPUT_BAR_DATA);
   const { title, date, category, paymentMethod, isIncome, amount } =
     currInputData;
-  const formattedDate = dateUtil.convertDateString(date);
+  const formattedDate = convertDateString(date);
   await request.createTransactionHistory(
     title,
     formattedDate,

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -40,6 +40,7 @@ async function initStore() {
     amount: null,
   };
   const inputBarState = 'CREATE';
+  const isInputBarValid = false;
 
   const initialData = {
     currentHeaderDate,
@@ -48,6 +49,7 @@ async function initStore() {
     paymentMethods,
     inputBarData,
     inputBarState,
+    isInputBarValid,
   };
   store.initStore(initialData);
 }

--- a/client/src/index.js
+++ b/client/src/index.js
@@ -32,10 +32,10 @@ async function initStore() {
     request.getPaymentMethods(),
   ]);
   const inputBarData = {
-    title: '',
+    title: null,
     date: new Date(),
-    categoryId: null,
-    paymentMethodId: null,
+    category: null,
+    paymentMethod: null,
     isIncome: false,
     amount: null,
   };

--- a/client/src/pages/MainPage.js
+++ b/client/src/pages/MainPage.js
@@ -1,11 +1,12 @@
 import Component from '@/base/component';
-
+import InputBar from '@/components/InputBar';
+import './page.css';
 export default class MainPage extends Component {
   constructor(parentNode) {
     super(parentNode, 'main');
   }
 
   render() {
-    this.currentNode.innerHTML = '<h2>MainPage</h2>';
+    new InputBar(this.currentNode);
   }
 }

--- a/client/src/pages/page.css
+++ b/client/src/pages/page.css
@@ -1,0 +1,7 @@
+main {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  background-color: var(--colors-background);
+}

--- a/client/src/store/index.js
+++ b/client/src/store/index.js
@@ -57,9 +57,9 @@ const store = (function () {
     return data.get(key);
   }
 
-  function setData(key, newData) {
+  function setData(key, newData, options = { rerender: true }) {
     data.set(key, newData);
-    notify(key);
+    if (options.rerender) notify(key);
   }
 
   return {

--- a/client/src/styles/global.css
+++ b/client/src/styles/global.css
@@ -63,9 +63,13 @@ button {
 }
 
 .container {
-  max-width: 80rem;
+  max-width: 53rem;
   margin: 0 auto;
   padding: 0 1.25rem;
+}
+
+.shadow {
+  box-shadow: 0px 4px 4px rgba(0, 0, 0, 0.1), 0px 4px 20px rgba(0, 0, 0, 0.1);
 }
 
 @media only screen and (min-width: 768px) {

--- a/client/src/utils/date-util.js
+++ b/client/src/utils/date-util.js
@@ -2,6 +2,23 @@ function getYearAndMonth(dateObj) {
   return { year: dateObj.getFullYear(), month: dateObj.getMonth() + 1 };
 }
 
+function convertDateString(dateObj) {
+  return dateObj.toISOString().split('T')[0];
+}
+
+function getFirstDateOfMonth(dateObj) {
+  const { year, month } = getYearAndMonth(dateObj);
+  return new Date(year, month - 1, 1);
+}
+
+function getLastDateOfMonth(dateObj) {
+  const { year, month } = getYearAndMonth(dateObj);
+  return new Date(year, month, 0);
+}
+
 export default {
   getYearAndMonth,
+  convertDateString,
+  getFirstDateOfMonth,
+  getLastDateOfMonth,
 };

--- a/client/src/utils/date-util.js
+++ b/client/src/utils/date-util.js
@@ -1,24 +1,17 @@
-function getYearAndMonth(dateObj) {
+export function getYearAndMonth(dateObj) {
   return { year: dateObj.getFullYear(), month: dateObj.getMonth() + 1 };
 }
 
-function convertDateString(dateObj) {
+export function convertDateString(dateObj) {
   return dateObj.toISOString().split('T')[0];
 }
 
-function getFirstDateOfMonth(dateObj) {
+export function getFirstDateOfMonth(dateObj) {
   const { year, month } = getYearAndMonth(dateObj);
   return new Date(year, month - 1, 1);
 }
 
-function getLastDateOfMonth(dateObj) {
+export function getLastDateOfMonth(dateObj) {
   const { year, month } = getYearAndMonth(dateObj);
   return new Date(year, month, 0);
 }
-
-export default {
-  getYearAndMonth,
-  convertDateString,
-  getFirstDateOfMonth,
-  getLastDateOfMonth,
-};


### PR DESCRIPTION
## 설명
- inputbar의 기본적인 기능 구현

## 작업한 내용
- store에 상태를 저장하면서 inputbar를 리렌더 하도록 구현
- 값을 전부 입력하면 등록버튼 클릭 가능

## 특이사항
- css styling을 다듬어야합니다. 그리고 현재 최상위 Index.css에 모여있습니다.
- 결제수단 모달의 경우 추가, 삭제같은 추가 기능 구현 필요합니다.
- 기타 ux적으로 좋지 않은 부분들을 업데이트 해야합니다.
    - ~~text, number input의 경우 포커스 아웃을 해야만 값이 등록되고 있습니다.~~ (해결)
    - 드롭다운 바깥을 누르면 꺼지도록 해야합니다.

## 관련이슈
- #27 
close #27 