### PR TITLE
[Fix] 달력 버그 픽스

### DIFF
--- a/client/src/controller/index.js
+++ b/client/src/controller/index.js
@@ -139,14 +139,14 @@ function changeFilterOptions(filterOption, isFiltered) {
   store.setData(STORE_KEYS.FILTER_OPTIONS, updatedFilterOptions);
 }
 
-function changeHeaderMonth(increment) {
+async function changeHeaderMonth(increment) {
   const headerDate = store.getData(STORE_KEYS.CURRENT_HEADER_DATE);
   headerDate.setDate(1);
   headerDate.setMonth(headerDate.getMonth() + increment);
+  await setCurrentMonthTransactionHistories(headerDate);
   store.setData(STORE_KEYS.CURRENT_HEADER_DATE, headerDate);
   store.setData(STORE_KEYS.CATEGORY_CHART_DATA, null);
   changeInputData([{ dataKey: INPUT_BAR_KEYS.DATE, value: headerDate }]);
-  setCurrentMonthTransactionHistories(headerDate);
   changeInputData(INPUT_BAR_KEYS.DATE, headerDate);
 }
 

--- a/client/src/utils/date-util.js
+++ b/client/src/utils/date-util.js
@@ -49,7 +49,7 @@ export function getAllDatesForCalendar(dateObj) {
   const calendarDates = [];
   const currentDate = getFirstDateOfCalendar(dateObj);
   while (
-    currentDate.getMonth() <= dateObj.getMonth() ||
+    currentDate <= getLastDateOfMonth(dateObj) ||
     calendarDates.length % 7 !== 0
   ) {
     calendarDates.push({


### PR DESCRIPTION
## 설명
- 달력 페이지에 존재하던 버그 수정

## 작업한 내용
- 기존 로직은 '달'의 크기로 이전 달을 체크했기 때문에 지난 년도 12월이 1월보다 크다고 판단.
- date 자체를 비교하도록 수정
