### PR TITLE
[FIX] INNER JOIN을 LEFT JOIN으로 변경

### DIFF
--- a/server/models/transaction-history.model.js
+++ b/server/models/transaction-history.model.js
@@ -16,9 +16,9 @@ const transactionHistoryModel = {
     const [[transactionHistory]] = await query(
       `SELECT T.id, T.title, T.isIncome, T.amount, T.date, T.paymentMethodId, P.title as paymentMethodTitle, T.categoryId, C.title as categoryTitle, C.color as categoryColor
       FROM TransactionHistory as T
-      INNER JOIN PaymentMethod as P
+      LEFT JOIN PaymentMethod as P
       ON T.paymentMethodId = P.id
-      INNER JOIN Category as C
+      LEFT JOIN Category as C
       ON T.categoryId = C.id
       WHERE T.id = ?
       LIMIT 1;`,
@@ -31,9 +31,9 @@ const transactionHistoryModel = {
     const [transactionHistories] = await query(
       `SELECT T.id, T.title, T.isIncome, T.amount, T.date, T.paymentMethodId, P.title as paymentMethodTitle, T.categoryId, C.title as categoryTitle, C.color as categoryColor
       FROM TransactionHistory as T
-      INNER JOIN PaymentMethod as P
+      LEFT JOIN PaymentMethod as P
       ON T.paymentMethodId = P.id
-      INNER JOIN Category as C
+      LEFT JOIN Category as C
       ON T.categoryId = C.id
       WHERE T.date BETWEEN ? AND ?;`,
       [startDate, endDate],
@@ -48,7 +48,7 @@ const transactionHistoryModel = {
       FROM (
         SELECT DATE_FORMAT(T.date, '%Y-%m') AS historyDate, SUM(T.amount) AS totalSpent
         FROM TransactionHistory as T
-        INNER JOIN Category as C
+        LEFT JOIN Category as C
         ON T.categoryId = C.id
         WHERE T.isIncome = 0 AND C.title = ?
         GROUP BY historyDate


### PR DESCRIPTION
## 설명
- Category와 PaymentMethod가 NULLABLE이 되면서 LEFTJOIN으로 변경

## 작업한 내용
- TransactionHistory의 SELECT QUERY에 사용되는 JOIN을 LEFTJOIN으로 변경


